### PR TITLE
Output versioned file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class Action {
 
         this._executeInProcess(`dotnet build -c Release ${this.projectFile}`)
 
-        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} --no-build -c Release ${this.projectFile} -o .`)
+        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} -p:PackageVersion=${version} --no-build -c Release ${this.projectFile} -o .`)
 
         const packages = fs.readdirSync(".").filter(fn => fn.endsWith("nupkg"))
         console.log(`Generated Package(s): ${packages.join(", ")}`)


### PR DESCRIPTION
Fix #43
Adding the PackageVersion parameter to the pack command will make the output file to respect it.