### PR TITLE
BUGFIX: fixes #58 where pushing package symbols produced false negatives

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class Action {
         const packages = fs.readdirSync(".").filter(fn => fn.endsWith("nupkg"))
         console.log(`Generated Package(s): ${packages.join(", ")}`)
 
-        const pushCmd = `dotnet nuget push *.nupkg -s ${this.nugetSource}/v3/index.json -k ${this.nugetKey} --skip-duplicate ${!this.includeSymbols ? "-n 1" : ""}`,
+        const pushCmd = `dotnet nuget push *.nupkg -s ${this.nugetSource}/v3/index.json -k ${this.nugetKey} --skip-duplicate${!this.includeSymbols ? " -n 1" : ""}`,
             pushOutput = this._executeCommand(pushCmd, { encoding: "utf-8" }).stdout
 
         console.log(pushOutput)


### PR DESCRIPTION
BUGFIX: fixes #58 where pushing package symbols produced false negatives. (Parameter cannot be null: path2)

Apparently, the errant space in the arguments makes the `_executeCommand` function think there's one more empty paramater at the end. This makes `dotnet nuget push` the package, the symbols, and a third empty package.

Simply transposing where the space appears in the ternary solves this problem.