### PR TITLE
Remove INCLUDE_SYMBOLS for project configured options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ jobs:
 
           # NuGet server uri hosting the packages, defaults to https://api.nuget.org
           # NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # INCLUDE_SYMBOLS: false
 ```
 
 - Project gets published only if there's a `NUGET_KEY` configured in the repository
@@ -73,7 +70,6 @@ TAG_COMMIT | `true` | Flag to toggle git tagging, enabled by default
 TAG_FORMAT | `v*` | Format of the git tag, `[*]` gets replaced with actual version
 NUGET_KEY | | API key to authenticate with NuGet server
 NUGET_SOURCE | `https://api.nuget.org` | NuGet server uri hosting the packages, defaults to https://api.nuget.org
-INCLUDE_SYMBOLS | `false` | Flag to toggle pushing symbols along with nuget package to the server, disabled by default
 
 ## Outputs
 
@@ -89,6 +85,9 @@ SYMBOLS_PACKAGE_PATH | Path to the generated symbols package
 - Outputs may or may not be set depending on the action inputs or if the action failed
 - `NUGET_SOURCE` must support `/v3-flatcontainer/PACKAGE_NAME/index.json` for version change detection to work
 - Multiple projects can make use of steps to configure each project individually, common inputs between steps can be given as `env` for [job / workflow](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#env)
+- When wanting to include symbols in an symbols package set these as well in the csproj or an ``Directory.Build.props`` file of the project being packaged:
+  - ``<IncludeSymbols>true</IncludeSymbols>``
+  - ``<SymbolPackageFormat>snupkg</SymbolPackageFormat>``
 
 ## License
 [MIT](LICENSE)


### PR DESCRIPTION
The options for these that can be set in msbuild props files / the csproj project file of the project that needs to be packed by the action would be honored by both ``dotnet pack`` and ``dotnet nuget push`` (the docs was not 100% clear on ``dotnet nuget push`` however but that is normal for Microsoft made docs).