### PR TITLE
include version into filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class Action {
 
         this._executeInProcess(`dotnet build -c Release ${this.projectFile}`)
 
-        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} --no-build -c Release ${this.projectFile} -o .`)
+        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} -p:Version=${this.version} --no-build -c Release ${this.projectFile} -o .`)
 
         const packages = fs.readdirSync(".").filter(fn => fn.endsWith("nupkg"))
         console.log(`Generated Package(s): ${packages.join(", ")}`)


### PR DESCRIPTION
Using the -p:Version flag allow dotnet pack to add the specified version to be included into the package 