### PR TITLE
Added Build configuration and platform target options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ jobs:
           # Filepath of the project to be packaged, relative to root of repository
           PROJECT_FILE_PATH: Core/Core.csproj
           
+          # Configuration to build and package
+          # BUILD_CONFIGURATION: Release
+          
+          # Platform target to compile (default is empty/AnyCPU)
+          # BUILD_PLATFORM: x64          
+          
           # NuGet package id, used for version detection & defaults to project name
           # PACKAGE_NAME: Core
           

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ jobs:
 Input | Default Value | Description
 --- | --- | ---
 PROJECT_FILE_PATH | | Filepath of the project to be packaged, relative to root of repository
+BUILD_CONFIGURATION | `Release` | Configuration to build and package
+BUILD_PLATFORM | | Platform target to compile
 PACKAGE_NAME | | NuGet package id, used for version detection & defaults to project name
 VERSION_FILE_PATH | `[PROJECT_FILE_PATH]` | Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
 VERSION_REGEX | `^\s*<Version>(.*)<\/Version>\s*$` | Regex pattern to extract version info in a capturing group

--- a/action.yml
+++ b/action.yml
@@ -9,15 +9,15 @@ inputs:
     BUILD_CONFIGURATION:
         description: Configuration to build and package (default is Release)
         required: false
-        default: Release        
-    NUSPEC_FILE:
-        description: file path to nuspec file
-        required: false
-        default: 
+        default: Release 
     BUILD_PLATFORM:
         description: Platform target to compile (default is empty/AnyCPU)
         required: false
         default: 
+    NUSPEC_FILE:
+        description: file path to nuspec file
+        required: false
+        default:
     PACKAGE_NAME:
         description: NuGet package id, used for version detection & defaults to project name
         required: false

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
         required: false
         default: Release
     BUILD_PLATFORM:
-        description: Platform target to compile (default is empty/Any-CPU)
+        description: Platform target to compile (default is empty/AnyCPU)
         required: false
         default: 
     PACKAGE_NAME:

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,11 @@ inputs:
     BUILD_CONFIGURATION:
         description: Configuration to build and package (default is Release)
         required: false
+        default: Release
     BUILD_PLATFORM:
         description: Platform target to compile (default is empty/Any-CPU)
         required: false
+        default: 
     PACKAGE_NAME:
         description: NuGet package id, used for version detection & defaults to project name
         required: false

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,11 @@ inputs:
     BUILD_CONFIGURATION:
         description: Configuration to build and package (default is Release)
         required: false
-        default: Release
+        default: Release        
+    NUSPEC_FILE:
+        description: file path to nuspec file
+        required: false
+        default: 
     BUILD_PLATFORM:
         description: Platform target to compile (default is empty/AnyCPU)
         required: false

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,12 @@ inputs:
     PROJECT_FILE_PATH:
         description: Filepath of the project to be packaged, relative to root of repository
         required: true
+    BUILD_CONFIGURATION:
+        description: Configuration to build and package (default is Release)
+        required: false
+    BUILD_PLATFORM:
+        description: Platform target to compile (default is empty/Any-CPU)
+        required: false
     PACKAGE_NAME:
         description: NuGet package id, used for version detection & defaults to project name
         required: false

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ const os = require("os"),
 class Action {
     constructor() {
         this.projectFile = process.env.INPUT_PROJECT_FILE_PATH
-        this.configuration = process.env.BUILD_CONFIGURATION || "Release"
-        this.platform = process.env.BUILD_PLATFORM || ""
+        this.configuration = process.env.INPUT_BUILD_CONFIGURATION
+        this.platform = process.env.INPUT_BUILD_PLATFORM
         this.packageName = process.env.INPUT_PACKAGE_NAME || process.env.PACKAGE_NAME
         this.versionFile = process.env.INPUT_VERSION_FILE_PATH || process.env.VERSION_FILE_PATH || this.projectFile
         this.versionRegex = new RegExp(process.env.INPUT_VERSION_REGEX || process.env.VERSION_REGEX, "m")

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ class Action {
         this.tagFormat = process.env.INPUT_TAG_FORMAT || process.env.TAG_FORMAT
         this.nugetKey = process.env.INPUT_NUGET_KEY || process.env.NUGET_KEY
         this.nugetSource = process.env.INPUT_NUGET_SOURCE || process.env.NUGET_SOURCE
+        this.nuspecFile = process.env.INPUT_NUSPEC_FILE
         this.includeSymbols = JSON.parse(process.env.INPUT_INCLUDE_SYMBOLS || process.env.INCLUDE_SYMBOLS)
     }
 
@@ -61,7 +62,7 @@ class Action {
 
         this._executeInProcess(`dotnet build -c ${this.configuration} ${this.projectFile} -p:Platform=${this.platform}`)
 
-        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} --no-build -c ${this.configuration} ${this.projectFile} -p:Platform=${this.platform} -o .`)
+        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} -p:NuspecFile=${this.nuspecFile} --no-build -c ${this.configuration} ${this.projectFile} -p:Platform=${this.platform} -o .`)
 
         const packages = fs.readdirSync(".").filter(fn => fn.endsWith("nupkg"))
         console.log(`Generated Package(s): ${packages.join(", ")}`)

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const os = require("os"),
 class Action {
     constructor() {
         this.projectFile = process.env.INPUT_PROJECT_FILE_PATH
+        this.configuration = process.env.BUILD_CONFIGURATION || "Release"
+        this.platform = process.env.BUILD_PLATFORM || ""
         this.packageName = process.env.INPUT_PACKAGE_NAME || process.env.PACKAGE_NAME
         this.versionFile = process.env.INPUT_VERSION_FILE_PATH || process.env.VERSION_FILE_PATH || this.projectFile
         this.versionRegex = new RegExp(process.env.INPUT_VERSION_REGEX || process.env.VERSION_REGEX, "m")
@@ -57,9 +59,9 @@ class Action {
 
         fs.readdirSync(".").filter(fn => /\.s?nupkg$/.test(fn)).forEach(fn => fs.unlinkSync(fn))
 
-        this._executeInProcess(`dotnet build -c Release ${this.projectFile}`)
+        this._executeInProcess(`dotnet build -c ${this.configuration} ${this.projectFile} -p:Platform=${this.platform}`)
 
-        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} --no-build -c Release ${this.projectFile} -o .`)
+        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} --no-build -c ${this.configuration} ${this.projectFile} -p:Platform=${this.platform} -o .`)
 
         const packages = fs.readdirSync(".").filter(fn => fn.endsWith("nupkg"))
         console.log(`Generated Package(s): ${packages.join(", ")}`)


### PR DESCRIPTION
Users can now specify BUILD_CONFIGURATION and BUILD_PLATFORM for their packages.  The defaults are Release with no target (AnyCPU).