### PR TITLE
Fixed bug in version regex.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     VERSION_REGEX:
         description: Regex pattern to extract version info in a capturing group
         required: false
-        default: ^\s*<Version>(.*)<\/Version>\s*$
+        default: ^\s*<(Package|)Version>(.*)<\/(Package|)Version>\s*$
     VERSION_STATIC:
         description: Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
         required: false


### PR DESCRIPTION
This would break pushing packages that set ``PackageVersion`` instead of ``Version`` in their project files.