### PR TITLE
Use master branch for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       # Publish
       - name: publish on version change
         id: publish_nuget
-        uses: brandedoutcast/publish-nuget@v2
+        uses: brandedoutcast/publish-nuget@master
         with:
           # Filepath of the project to be packaged, relative to root of repository
           PROJECT_FILE_PATH: Core/Core.csproj


### PR DESCRIPTION
The example uses only the v2 releases. As there are no new releases and the master is still updated, It might be a better idea to suggest to use the master branch in the example.