### PR TITLE
Use v3-flatcontainer API with lower-case package name

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ class Action {
 
         console.log(`Package Name: ${this.packageName}`)
 
-        https.get(`${this.nugetSource}/v3-flatcontainer/${this.packageName}/index.json`, res => {
+        https.get(`${this.nugetSource}/v3-flatcontainer/${this.packageName.toLowerCase()}/index.json`, res => {
             let body = ""
 
             if (res.statusCode == 404)


### PR DESCRIPTION
I just stumbled across this issue and had to manually change my PACKAGE_NAME to be lower-case.
However, this feels like a workaround, because my package name is actually not lower-case.

See also: https://github.com/NuGet/NuGetGallery/issues/9105